### PR TITLE
Fix build failure when fetching Google Fonts

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,19 +1,13 @@
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
-import { Inter } from "@next/font/google";
 import { Analytics } from "@vercel/analytics/react";
-
-const inter = Inter({
-  variable: "--font-inter",
-  subsets: ["latin"],
-});
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <div className={inter.variable}>
+    <>
       <Component {...pageProps} />
       <Analytics />
-    </div>
+    </>
   );
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --font-inter: "Inter", system-ui, sans-serif;
+}
+
+body {
+  font-family: var(--font-inter), system-ui, sans-serif;
+}


### PR DESCRIPTION
## Summary
- remove the `@next/font/google` dependency from the custom App component to avoid network requests during builds
- provide a global CSS variable fallback so the Inter font stack still applies across the site

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d3a1f571608328b055e505e8a70c4c